### PR TITLE
Fix name of Azure Boards

### DIFF
--- a/_posts/2019-06-25-scaling-25k.md
+++ b/_posts/2019-06-25-scaling-25k.md
@@ -417,7 +417,7 @@ with policy, and inform leaders about important open source decisions that are
 being made.
 
 We have an internal service called the Usage Service that creates a work item
-in our work item tracking system (Azure DevOps Boards), and assigns that work
+in our work item tracking system (Azure Boards), and assigns that work
 item to the appropriate legal and business reviewer. The work item is then
 passed along, with fields or more info being filled out, discussions are had, and
 eventually the review will be "final approved" and ready for teams to ship their


### PR DESCRIPTION
No need for 'DevOps' in the Azure Boards service name - 6 less characters to read ;)