### PR TITLE
EV: 2022 updates

### DIFF
--- a/_posts/2019-11-25-evcondo.md
+++ b/_posts/2019-11-25-evcondo.md
@@ -57,6 +57,12 @@ multi-family communities to efficiently invest in charging infrastructure to rem
 new developers are monetizing these code requirements by selling EV-enabled parking spaces similar to a granite 
 kitchen backsplash upgrade.
 
+> March 2022 update:
+> Washington State has passed a right-to-charge law that goes into effect in
+> June 2022, [HB 1793](https://app.leg.wa.gov/billsummary?BillNumber=1793&Year=2021&Initiative=false),
+> that will significantly improve the situation for multifamily residences going
+> forward.
+
 A condo building's units are owned by individuals who form the members of a Home Owner's Association (HOA),
 governed by a board elected by the members, and all rights and privileges are granted through laws and
 the association's governing documents and rules.
@@ -144,8 +150,8 @@ Having two separate switchgear turns out to be a significant positive developmen
   residential units._
 
 If we had not identified such a place, we would have had to work with the utility to
-bring in additional service, enlarge existing service, update switchgear with new breakers,
-etc. A risk with a larger utility transformer can be fees if you do not end up utilizing the
+bring in additional service, access more from the city's vault, update switchgear with new breakers,
+etc. A risk with a service increase can be fees if you do not end up utilizing the
 new capacity sufficiently.
 
 We also learned that we could use the peak demand data to work with inspectors to install
@@ -251,11 +257,6 @@ the compromise was that a policy, contingent on a sufficient number of reservati
 be approved. Reservations would be accepted on a first-come, first-served basis for
 cicuits, and be refundable only if the project is not approved.
 
-The price of reservations was set slightly higher than the anticipated cost of a share
-of the infrastructure work, so that if all available circuits were reserved, the project
-would be fully funded by the owners, and a small surplus of money could be saved in an
-account for future EV project planning.
-
 The board, taking community input, decided that if 5 reservations were placed, they
 would approve the project.
 
@@ -278,7 +279,7 @@ the net new energy used, at cost.
 
 <img src="{{ site.cdn }}2019ev/submeters.jpg" class="img-responsive" title="" />
 
-_A sub-meter adds around $1,000 to the installation cost of each spoke circuit. If
+_A sub-meter adds around $900 to the installation cost of each spoke circuit. If
 our declaration had been worded differently, we likely would not have required sub-meters
 and instead considered other approaches that other buildings have used. However, this
 was the most fair to the owners and board at the time of the decision._
@@ -292,7 +293,7 @@ and policies.
 The three fees eventually agreed upon for the project were:
 
 1. The one-time, non-refundable reservation fee to have a circuit assigned in the project.
-2. An annual fee of $50 to cover the minimal overhead of the project
+2. An annual fee of $50 to cover the minimal overhead of the project (meter-reading by staff)
   - Quarterly meter reading by our staff, and processing of payments
   - Any credit card fees associated with energy reimbursement
 3. Quarterly energy reimbursement
@@ -354,7 +355,7 @@ We decided not to offer larger breaker sizes in this project to
 maximize participation:
 
 - 40-amp EVSE on a 50-amp circuit (a very common EV circuit size)
-- 50-amp, 60-amp and 80-amp (not necessary unless load sharing among multiple chargers)
+- 50-amp, 60-amp and 80-amp (not necessary unless load sharing among multiple chargers or older dual-charger Teslas)
 
 There's a lot of FUD from people less familiar with EVs - especially Audi dealers -
 that you need to have the largest size installation, otherwise "your e-tron will take
@@ -364,11 +365,11 @@ days to charge."
 
 ### Infrastructure cost
 
-<img src="{{ site.cdn }}2019ev/transformerpad.jpg" class="img-responsive" title="" />
+<img src="{{ site.cdn }}2019ev/transformerpad.jpg" class="img-responsive" title="The transformer pad" />
 
 The best bid that we had on this project was as follows:
 
-- $10,900
+- $11,000-ish (2019)
   - Purchase an electrical permit and have the work inspected/signed-off by the authority having jurisdiction
   - Pre-inspection review of project
   - Purchase and install a switchgear breaker
@@ -378,7 +379,7 @@ The best bid that we had on this project was as follows:
 - $300
   - Provide and install 7 2P-40A and 1 2P-25A breakers
 
-Total of just over $11,000. There was no sales tax thanks to a Washington State
+There was no sales tax thanks to a Washington State
 EV infrastructure exemption. Originally set to expire in 2019, it's since been
 extended into 2025.
 
@@ -414,12 +415,6 @@ few of the owners believed the initial quotes that installs could be "$5,000 or 
 hindsight, we should have required that owners provided at least 1 quote to show that
 they were very serious about the project and aware of the potential costs involved
 in building out their spoke of the system.
-
-In the month following the approval, 5 owners paid the reservation fee, and the board
-approved the electric infrastructure upgrades. The cost of the upgrades was around $11,000,
-and with 5 owners reserved (4x 32-amp chargers and 1x 20-amp charger), the associated had
-received $9,000, and once the additional reservations were sold, the project would have a
-surplus.
 
 ## Construction begins
 
@@ -460,9 +455,8 @@ be impacted.
 
 ## Project completion
 
-In May, we received our 8th reservation check and the board closed the project
-to new reservations. Our treasurer setup a new account dedicated to future EV
-projects with the proceeds.
+In May, we received our 8th reservation and the board closed the project
+to new reservations.
 
 Several of the owners went forward with ordering new cars such as the Tesla Model 3
 and taking delivery.
@@ -475,6 +469,9 @@ the owner taking eventual delivery in 2020 or 2021 of an Audi they wanted to wai
 In the garage we now see several Teslas, another Chevy Volt, a Chevy Bolt, and the
 community charger is now being used by 6 owners at various times who chose not
 to invest in the Limited Common charging project.
+
+> 2022 Update:
+> There are electric vehicles everywhere in the garage, about 20 Teslas, some VW ID4's.
 
 ## Retrospective learnings
 
@@ -597,33 +594,6 @@ owners asked why progress was not being made on investigating a plan
 or policy for EV charging. It was clear that a few people would
 need to go get involved in learning about the real options.
 
-## Air Conditioning policy
-
-When our building was constructed, only the top 2 floors of the tower
-offered HVAC air conditioning. All other units did not have air
-conditioning.
-
-A/C was not common in a majority of Seattle homes until more recently,
-so this building being built in 2002 did not see A/C as a major feature.
-
-Since then, the condo market has evolved, and more people expect to
-have A/C charging for the month or so of warmth each summer, so owners
-had asked a lot about how to go about installing charging capabilities.
-
-Similar to the EV project, every year or two, people would ask about A/C,
-and conversations started as early at 2005. A decade later, by 2016, there
-was finally a policy that would allow a specific set of requirements to be
-met in order to mount A/C split units on Limited Common balconies.
-
-This policy and managing the fear and uncertainty during the process helped
-forge a good foundation for a similar approach for our EV project.
-
-Additionally, the A/C project clearly defined that there was a path to
-owners paying, at their own cost, for a professional to make an
-improvement that only benefits some owners. Installs easily cost as
-much as $15,000 and demonstrated that if you provide a path and framework
-for people, with a policy, they will appreciate it.
-
 ## Garage WiFi
 
 As part of a building-wide security camera project, we moved from a traditional
@@ -717,6 +687,11 @@ to the outlet before use, then return the key after using and disconnecting the 
 > In hindsight, we probably should have considered a networked ChargePoint-style system
 > that would allow owners to have their own ChargePoint card, then we would set a rate,
 > and billing would be easy and automatic, with no need to work with our concierge staff.
+>
+> 2022 update: we've had several ChargePoint bids over the years, it's a non-starter.
+> They're definitely priced for commercial business installations and not able to
+> compete effectively in the residential space. Expensive units, monthly service fees,
+> requirements to install cell repeaters, etc.
 
 # Deciding to wait (2010-2014)
 


### PR DESCRIPTION
adding Washington right-to-charge law that goes into effect in June 2022 updates, minor other clarification